### PR TITLE
feat: Port poker server to Cloudflare Workers + Durable Objects

### DIFF
--- a/src/board-games/poker/logic/PokerNetworking.ts
+++ b/src/board-games/poker/logic/PokerNetworking.ts
@@ -1,12 +1,12 @@
-import io from 'socket.io-client';
-import { wait } from '../../../util/Async';
+
 import { GameData } from '../data/GameData';
 import { Card, toCard } from '../data/Card';
 import { Player, toPlayer } from '../data/Player';
 import { isLocalhost } from '../../../util/Localhost';
 
-const PROD_SERVER = 'https://novelty-games.mooo.com:8080';
-const DEV_SERVER = 'localhost:8080';
+// Cloudflare Workers poker server (Durable Objects backend)
+const PROD_SERVER = 'wss://novelty-poker.jane-sturdyhippo.workers.dev';
+const DEV_SERVER = 'ws://localhost:8787';
 
 const LOBBY_NAME = 'Novelty Games';
 const STARTING_CHIPS = 100;
@@ -47,7 +47,10 @@ export function createPokerNetworking(): PokerNetworking {
     if (instance !== null) return instance;
 
     const url = isLocalhost() ? DEV_SERVER : PROD_SERVER;
-    const socket = io(url);
+
+    // Connect WebSocket with room name as query param
+    const wsUrl = `${url}/?room=${encodeURIComponent(LOBBY_NAME)}`;
+    const socket = new WebSocket(wsUrl);
 
     let username = 'username';
 
@@ -61,98 +64,134 @@ export function createPokerNetworking(): PokerNetworking {
         message: () => { }
     };
 
-    socket.onAny((eventName, args) => {
-        if (eventName === 'badJoin') return;
-        if (eventName === 'goodJoin') return;
-        if (eventName === 'gameBegun') return;
-        if (eventName === 'roomUsers') return;
-        if (eventName === 'roomPlayers') return;
-        if (eventName === 'yourTurn') return;
-        if (eventName === 'potSize') return;
-        if (eventName === 'dealBoard') return;
-        if (eventName === 'message') return;
-        if (eventName === 'allIn') return;
-        if (eventName === 'consoleLog') return;
-        if (eventName === 'hands') return;
-        if (eventName === 'validOption') return;
+    // Send a JSON message to the server
+    const send = (type: string, data?: any) => {
+        if (socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type, data }));
+        }
+    };
 
-        console.log(`Unhandled event: ${eventName}`, args);
+    // Wait for connection to be open, then send
+    const sendWhenReady = (type: string, data?: any) => {
+        if (socket.readyState === WebSocket.OPEN) {
+            send(type, data);
+        } else {
+            socket.addEventListener('open', () => send(type, data), { once: true });
+        }
+    };
+
+    // Handle incoming messages (dispatch by type)
+    socket.addEventListener('message', (event: MessageEvent) => {
+        let parsed: any;
+        try {
+            parsed = JSON.parse(event.data);
+        } catch {
+            console.warn('Received non-JSON message:', event.data);
+            return;
+        }
+
+        const { type, data } = parsed;
+
+        switch (type) {
+            case 'badJoin': {
+                // Room doesn't exist or name taken — try to create it then join
+                send('createRoom', {
+                    username: null,
+                    stacksize: 0,
+                    lobbyname: LOBBY_NAME,
+                    smallBlind: 1,
+                    bigBlind: 2,
+                    password: ''
+                });
+                setTimeout(() => {
+                    send('joinRoom', [LOBBY_NAME, username, STARTING_CHIPS]);
+                }, 1000);
+                break;
+            }
+
+            case 'goodJoin': {
+                send('joinRoom', [LOBBY_NAME, username, STARTING_CHIPS]);
+                break;
+            }
+
+            case 'gameBegun':
+                callbacks.gameBegun();
+                break;
+
+            case 'roomUsers': {
+                const users = data.users as string[];
+                callbacks.roomUsers(users);
+                break;
+            }
+
+            case 'roomPlayers': {
+                // data is an array: [dealerIndex, ...playerObjects]
+                const arr = Array.isArray(data) ? data : [];
+                const players = arr.slice(1).map((p: any) => toPlayer(p)) as Player[];
+                const player = players.find(p => p.name === username);
+
+                if (player) {
+                    const maxInPot = Math.max(...players.filter(p => p.lastAction !== 'Folded').map(p => p.inPot));
+                    const toCall = maxInPot - player.inPot;
+
+                    const gameData: GameData = {
+                        player: player,
+                        players: players,
+                        toCall: toCall
+                    };
+
+                    callbacks.gameUpdate(gameData);
+                }
+                break;
+            }
+
+            case 'yourTurn':
+                callbacks.yourTurn();
+                break;
+
+            case 'potSize':
+                callbacks.potUpdate(data);
+                break;
+
+            case 'dealBoard':
+                callbacks.dealBoard(data.map((c: any) => toCard(c)));
+                break;
+
+            case 'message':
+                callbacks.message(data);
+                break;
+
+            case 'allIn':
+                send('playerTurn', 'playerIsAllIn');
+                break;
+
+            case 'consoleLog':
+                callbacks.message(data);
+                break;
+
+            case 'hands':
+            case 'validOption':
+                // Ignored - same as original
+                break;
+
+            default:
+                console.log(`Unhandled event: ${type}`, data);
+                break;
+        }
     });
 
-    socket.on('badJoin', async _ => {
-        socket.emit('createRoom', {
-            username: null,
-            stacksize: 0,
-            lobbyname: LOBBY_NAME,
-            smallBlind: 1,
-            bigBlind: 2,
-            password: ''
-        });
-
-        await wait(1000);
-
-        socket.emit('joinRoom', [
-            LOBBY_NAME,
-            username,
-            STARTING_CHIPS
-        ]);
+    socket.addEventListener('error', (event: Event) => {
+        console.error('WebSocket error:', event);
     });
 
-    socket.on('goodJoin', _ => {
-        socket.emit('joinRoom', [
-            LOBBY_NAME,
-            username,
-            STARTING_CHIPS
-        ]);
+    socket.addEventListener('close', () => {
+        console.log('WebSocket disconnected');
     });
-
-    socket.on('gameBegun', () => {
-        callbacks.gameBegun();
-    });
-
-    socket.on('roomUsers', data => {
-        const users = data.users as string[];
-        callbacks.roomUsers(users);
-    });
-
-    socket.on('roomPlayers', data => {
-        // const dealerIndex = data[0] as number;
-
-        const players = data.splice(1).map((p: any) => toPlayer(p)) as Player[];
-        const player = players.find(p => p.name === username)!;
-
-        const maxInPot = Math.max(...players.filter(p => p.lastAction !== 'Folded').map(p => p.inPot));
-        const toCall = maxInPot - player.inPot;
-
-        const gameData: GameData = {
-            player: player,
-            players: players,
-            toCall: toCall
-        };
-
-        callbacks.gameUpdate(gameData);
-    });
-
-    socket.on('yourTurn', () => callbacks.yourTurn());
-
-    socket.on('potSize', pot => callbacks.potUpdate(pot));
-
-    socket.on('dealBoard', cards => callbacks.dealBoard(cards.map((c: any) => toCard(c))));
-
-    socket.on('message', message => callbacks.message(message));
-
-    socket.on('allIn', () => socket.emit('playerTurn', 'playerIsAllIn'));
-
-    socket.on('consoleLog', text => callbacks.message(text));
-
-    socket.on('hands', () => { /* Ignore */ });
-    socket.on('validOption', () => { /* Ignore */ });
 
     instance = {
         connect: (name) => {
             username = name;
-
-            socket.emit('joinAttempt', {
+            sendWhenReady('joinAttempt', {
                 username: username,
                 stackSize: STARTING_CHIPS,
                 lobbyname: LOBBY_NAME,
@@ -161,11 +200,11 @@ export function createPokerNetworking(): PokerNetworking {
         },
 
         startGame: () => {
-            socket.emit('startGame');
+            send('startGame');
         },
 
         takeAction: (action) => {
-            socket.emit('playerTurn', getActionValue(action));
+            send('playerTurn', getActionValue(action));
         },
 
         onGameBegun: callback => callbacks.gameBegun = callback,


### PR DESCRIPTION
## Overview

Ports the poker game server from Node.js/Express/socket.io to **Cloudflare Workers with Durable Objects**. This eliminates the need for a dedicated server and moves to serverless infrastructure.

## Architecture

### Backend (deployed separately as a Cloudflare Worker)
- Worker entry point: Routes WebSocket upgrades to Durable Objects by room name
- PokerRoom Durable Object: One DO per poker room — manages WebSocket connections, game state, event routing
- Game logic ported from original JS to TypeScript (card, deck, player, handEvaluator, pokerGame, pokerHand)
- Key adaptations: socket.io replaced with injected broadcast callbacks, setTimeout replaced with DO alarms

### Frontend change (this PR)
- `PokerNetworking.ts`: Replaced `socket.io-client` with native `WebSocket` API
  - Connects to `wss://novelty-poker.jane-sturdyhippo.workers.dev/?room=Novelty+Games`
  - Sends/receives JSON messages `{type, data}` instead of socket.io events
  - All event handlers preserved (joinAttempt, createRoom, joinRoom, startGame, playerTurn, etc.)
  - Auto-create-room-on-badJoin flow preserved

### Key design decisions
1. One Durable Object per poker room (keyed by lobby name)
2. Non-hibernating WebSockets (complex game state cannot be serialized across hibernation)
3. DO alarms replace setTimeout for scheduling new hands
4. Express/Let's Encrypt layer removed — Cloudflare handles TLS natively
5. socket.io replaced with raw WebSocket + simple JSON protocol

## Deployed endpoint

Worker is live at: `wss://novelty-poker.jane-sturdyhippo.workers.dev`

## Testing

- TypeScript compiles with zero errors
- Worker deployed successfully with Durable Object binding
- Frontend event protocol matches original socket.io events 1:1

## Notes

- Backend Worker code lives in a separate repo. This PR only changes the frontend networking layer.
- `SocketIoCommunicator.ts` (used by other games) is unchanged.
- `socket.io-client` dependency remains for other games that still use it.